### PR TITLE
Stemmer improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,14 @@ phf_codegen = "0.7"
 maplit = "1"
 
 [dependencies]
-lazy_static = "0.2"
+lazy_static = "1"
 phf = "0.7"
 regex = "0.2"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+
+[features]
+default = []
+nightly = ["bench"]
+bench = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@
 //!file.write_all(index.to_json_pretty().as_bytes());
 //!```
 
+#![cfg_attr(all(test, feature = "bench"), feature(test))]
+
 #[macro_use]
 extern crate lazy_static;
 extern crate phf;

--- a/src/stemmer.rs
+++ b/src/stemmer.rs
@@ -75,12 +75,16 @@ impl Stemmer {
         let re4_1b_2 = Regex::new(&concat_buf!("^", C, v, "[^aeiouwxy]$")).unwrap();
 
         let re_1c = Regex::new("^(.+?[^aeiou])y$").unwrap();
-        let re_2 = Regex::new("^(.+?)(ational|tional|enci|anci|izer|bli|alli|entli|eli|ousli|\
-            ization|ation|ator|alism|iveness|fulness|ousness|aliti|iviti|biliti|logi)$").unwrap();
+        let re_2 = Regex::new(
+            "^(.+?)(ational|tional|enci|anci|izer|bli|alli|entli|eli|ousli|\
+             ization|ation|ator|alism|iveness|fulness|ousness|aliti|iviti|biliti|logi)$",
+        ).unwrap();
 
         let re_3 = Regex::new("^(.+?)(icate|ative|alize|iciti|ical|ful|ness)$").unwrap();
 
-        let re_4 = Regex::new("^(.+?)(al|ance|ence|er|ic|able|ible|ant|ement|ment|ent|ou|ism|ate|iti|ous|ive|ize)$").unwrap();
+        let re_4 = Regex::new(
+            "^(.+?)(al|ance|ence|er|ic|able|ible|ant|ement|ment|ent|ou|ism|ate|iti|ous|ive|ize)$",
+        ).unwrap();
         let re2_4 = Regex::new("^(.+?)(s|t)(ion)$").unwrap();
 
         let re_5 = Regex::new("^(.+?)e$").unwrap();
@@ -131,26 +135,26 @@ impl Stemmer {
 
         // Step 1a
         if let Some(caps) = self.re_1a.captures(&w.clone()) {
-            w = concat_buf!(caps.get(1).unwrap().as_str(), caps.get(2).unwrap().as_str());
+            w = concat_buf!(&caps[1], &caps[2]);
         }
         if let Some(caps) = self.re2_1a.captures(&w.clone()) {
-            w = concat_buf!(caps.get(1).unwrap().as_str(), caps.get(2).unwrap().as_str());
+            w = concat_buf!(&caps[1], &caps[2]);
         }
 
         // Step 1b
         if let Some(caps) = self.re_1b.captures(&w.clone()) {
-            let stem = caps.get(1).unwrap().as_str();
+            let stem = &caps[1];
             if self.re_mgr0.is_match(stem) {
                 w = self.re_1b_2.replace(&w, "").into();
             }
         } else if let Some(caps) = self.re2_1b.captures(&w.clone()) {
-            let stem = caps.get(1).unwrap().as_str();
+            let stem = &caps[1];
             if self.re_s_v.is_match(&stem) {
                 w = stem.into();
                 if self.re2_1b_2.is_match(&w) {
                     w.push('e');
-                } else if let Some(caps) = self.re3_1b_2.captures(&w.clone()) {
-                    let suffix = caps.get(0).unwrap().as_str();
+                } else if let Some(m) = self.re3_1b_2.find(&w.clone()) {
+                    let suffix = m.as_str();
                     // Make sure the two characters are the same since we can't use backreferences
                     if suffix[0..1] == suffix[1..2] {
                         w = self.re_1b_2.replace(&w, "").into();
@@ -164,14 +168,14 @@ impl Stemmer {
         // Step 1c - replace suffix y or Y by i if preceded by a non-vowel which is not the first
         // letter of the word (so cry -> cri, by -> by, say -> say)
         if let Some(caps) = self.re_1c.captures(&w.clone()) {
-            let stem = caps.get(1).unwrap().as_str();
+            let stem = &caps[1];
             w = concat_buf!(stem, "i");
         }
 
         // Step 2
         if let Some(caps) = self.re_2.captures(&w.clone()) {
-            let stem = caps.get(1).unwrap().as_str();
-            let suffix = caps.get(2).unwrap().as_str();
+            let stem = &caps[1];
+            let suffix = &caps[2];
             if self.re_mgr0.is_match(&stem) {
                 w = concat_buf!(stem, step2list.get(suffix).unwrap());
             }
@@ -179,8 +183,8 @@ impl Stemmer {
 
         // Step 3
         if let Some(caps) = self.re_3.captures(&w.clone()) {
-            let stem = caps.get(1).unwrap().as_str();
-            let suffix = caps.get(2).unwrap().as_str();
+            let stem = &caps[1];
+            let suffix = &caps[2];
             if self.re_mgr0.is_match(&stem) {
                 w = concat_buf!(stem, step3list.get(suffix).unwrap());
             }
@@ -188,12 +192,12 @@ impl Stemmer {
 
         // Step 4
         if let Some(caps) = self.re_4.captures(&w.clone()) {
-            let stem = caps.get(1).unwrap().as_str();
+            let stem = &caps[1];
             if self.re_mgr1.is_match(&stem) {
                 w = stem.into();
             }
         } else if let Some(caps) = self.re2_4.captures(&w.clone()) {
-            let stem = concat_buf!(caps.get(1).unwrap().as_str(), caps.get(2).unwrap().as_str());
+            let stem = concat_buf!(&caps[1], &caps[2]);
             if self.re_mgr1.is_match(&stem) {
                 w = stem.into();
             }
@@ -201,9 +205,9 @@ impl Stemmer {
 
         // Step 5
         if let Some(caps) = self.re_5.captures(&w.clone()) {
-            let stem = caps.get(1).unwrap().as_str();
-            if self.re_mgr1.is_match(&stem) ||
-                (self.re_meq1.is_match(&stem) && !(self.re3_5.is_match(&stem)))
+            let stem = &caps[1];
+            if self.re_mgr1.is_match(&stem)
+                || (self.re_meq1.is_match(&stem) && !(self.re3_5.is_match(&stem)))
             {
                 w = stem.into();
             }
@@ -232,6 +236,8 @@ pub fn stemmer(input: String) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "bench")]
+    extern crate test;
     use super::*;
 
     #[test]
@@ -322,5 +328,40 @@ mod tests {
         for &(input, output) in cases.iter() {
             assert_eq!(&stemmer(input.into()).unwrap(), output);
         }
+    }
+
+    #[cfg(feature = "bench")]
+    #[bench]
+    fn bench_stem(b: &mut test::Bencher) {
+        b.iter(|| 
+            test::black_box(stemmer(String::from(TEXT)))
+        );
+
+        const TEXT: &str = "
+            I am already far north of London, and as I walk in the streets of Petersburgh, I feel a cold 
+            northern breeze play upon my cheeks, which braces my nerves and fills me with delight. Do you 
+            understand this feeling? This breeze, which has travelled from the regions towards which I am 
+            advancing, gives me a foretaste of those icy climes. Inspirited by this wind of promise, my 
+            daydreams become more fervent and vivid. I try in vain to be persuaded that the pole is the seat of 
+            frost and desolation; it ever presents itself to my imagination as the region of beauty and delight.
+            There, Margaret, the sun is forever visible, its broad disk just skirting the horizon and diffusing
+            a perpetual splendour. There—for with your leave, my sister, I will put some trust in preceding 
+            navigators—there snow and frost are banished; and, sailing over a calm sea, we may be wafted to a 
+            land surpassing in wonders and in beauty every region hitherto discovered on the habitable globe. 
+            productions and features may be without example, as the phenomena of the heavenly bodies 
+            undoubtedly are in those undiscovered solitudes. What may not be expected in a country of eternal 
+            light? I may there discover the wondrous power which attracts the needle and may regulate a 
+            thousand celestial observations that require only this voyage to render their seeming 
+            eccentricities consistent forever. I shall satiate my ardent curiosity with the sight of a part of
+            the world never before visited, and may tread a land never before imprinted by the foot of man. 
+            These are my enticements, and they are sufficient to conquer all fear of danger or death and to 
+            induce me to commence this laborious voyage with the joy a child feels when he embarks in a 
+            little boat, with his holiday mates, on an expedition of discovery up his native river. But 
+            supposing all these conjectures to be false, you cannot contest the inestimable benefit which I 
+            shall confer on all mankind, to the last generation, by discovering a passage near the pole to 
+            those countries, to reach which at present so many months are requisite; or by ascertaining the 
+            secret of the magnet, which, if at all possible, can only be effected by an undertaking such as 
+            mine. 
+            ";
     }
 }

--- a/src/stemmer.rs
+++ b/src/stemmer.rs
@@ -151,15 +151,23 @@ impl Stemmer {
             let stem = &caps[1];
             if self.re_s_v.is_match(&stem) {
                 w = stem.into();
+
+                let mut re3_1b_2_matched = false;
+
                 if self.re2_1b_2.is_match(&w) {
                     w.push('e');
                 } else if let Some(m) = self.re3_1b_2.find(&w.clone()) {
                     let suffix = m.as_str();
                     // Make sure the two characters are the same since we can't use backreferences
                     if suffix[0..1] == suffix[1..2] {
+                        re3_1b_2_matched = true;
                         w = self.re_1b_2.replace(&w, "").into();
                     }
-                } else if self.re4_1b_2.is_match(&w) {
+                }
+
+                // re4_1b_2 still runs if re3_1b_2 matches but
+                // the matched chcaracters are not the same
+                if !re3_1b_2_matched && self.re4_1b_2.is_match(&w) {
                     w.push('e');
                 }
             }

--- a/src/stemmer.rs
+++ b/src/stemmer.rs
@@ -335,9 +335,13 @@ mod tests {
     #[cfg(feature = "bench")]
     #[bench]
     fn bench_stem(b: &mut test::Bencher) {
-        b.iter(|| 
-            test::black_box(stemmer(String::from(TEXT)))
-        );
+        let data = ::pipeline::tokenize(TEXT);
+        b.iter(|| {
+            let d = data.clone();
+            for word in d {
+                test::black_box(stemmer(word));
+            }
+        });
 
         const TEXT: &str = "
             I am already far north of London, and as I walk in the streets of Petersburgh, I feel a cold 

--- a/src/stemmer.rs
+++ b/src/stemmer.rs
@@ -18,7 +18,6 @@ struct Stemmer {
     re2_1a: Regex,
     re_1b: Regex,
     re2_1b: Regex,
-    re_1b_2: Regex,
     re2_1b_2: Regex,
     re3_1b_2: Regex,
     re4_1b_2: Regex,
@@ -32,7 +31,6 @@ struct Stemmer {
     re2_4: Regex,
 
     re_5: Regex,
-    re_5_1: Regex,
     re3_5: Regex,
 }
 
@@ -69,7 +67,6 @@ impl Stemmer {
         let re2_1a = Regex::new("^(.+?)([^s])s$").unwrap();
         let re_1b = Regex::new("^(.+?)eed$").unwrap();
         let re2_1b = Regex::new("^(.+?)(ed|ing)$").unwrap();
-        let re_1b_2 = Regex::new(".$").unwrap();
         let re2_1b_2 = Regex::new("(at|bl|iz)$").unwrap();
         let re3_1b_2 = Regex::new("([^aeiouylsz]{2})$").unwrap();
         let re4_1b_2 = Regex::new(&concat_buf!("^", C, v, "[^aeiouwxy]$")).unwrap();
@@ -88,7 +85,6 @@ impl Stemmer {
         let re2_4 = Regex::new("^(.+?)(s|t)(ion)$").unwrap();
 
         let re_5 = Regex::new("^(.+?)e$").unwrap();
-        let re_5_1 = Regex::new("ll$").unwrap();
         let re3_5 = Regex::new(&concat_buf!("^", C, v, "[^aeiouwxy]$")).unwrap();
 
         Stemmer {
@@ -100,7 +96,6 @@ impl Stemmer {
             re2_1a,
             re_1b,
             re2_1b,
-            re_1b_2,
             re2_1b_2,
             re3_1b_2,
             re4_1b_2,
@@ -110,7 +105,6 @@ impl Stemmer {
             re_4,
             re2_4,
             re_5,
-            re_5_1,
             re3_5,
         }
     }
@@ -145,7 +139,7 @@ impl Stemmer {
         if let Some(caps) = self.re_1b.captures(&w.clone()) {
             let stem = &caps[1];
             if self.re_mgr0.is_match(stem) {
-                w = self.re_1b_2.replace(&w, "").into();
+                w.pop();
             }
         } else if let Some(caps) = self.re2_1b.captures(&w.clone()) {
             let stem = &caps[1];
@@ -161,7 +155,7 @@ impl Stemmer {
                     // Make sure the two characters are the same since we can't use backreferences
                     if suffix[0..1] == suffix[1..2] {
                         re3_1b_2_matched = true;
-                        w = self.re_1b_2.replace(&w, "").into();
+                        w.pop();
                     }
                 }
 
@@ -221,8 +215,8 @@ impl Stemmer {
             }
         }
 
-        if self.re_5_1.is_match(&w) && self.re_mgr1.is_match(&w) {
-            w = self.re_1b_2.replace(&w, "").into();
+        if w.ends_with("ll") && self.re_mgr1.is_match(&w) {
+            w.pop();
         }
 
         // and turn initial Y back to y


### PR DESCRIPTION
- Remove some trivial regexes
- Add benchmark for stemmer
- Fix bug in 3_1b_2 (see comment)
- Remove unnecessary use of regex features (w.pop() instead of replace(), find() instead of captures())