### PR TITLE
Stable JSON output after replacing HashMaps with BTreeMaps

### DIFF
--- a/src/document_store.rs
+++ b/src/document_store.rs
@@ -1,6 +1,6 @@
 //! Implements an elasticlunr.js document store. Most users do not need to use this module directly.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// The document store saves the complete text of each item saved to the index, if enabled.
 /// Most users do not need to use this type directly.
@@ -8,8 +8,8 @@ use std::collections::HashMap;
 #[serde(rename_all = "camelCase")]
 pub struct DocumentStore {
     pub save: bool,
-    pub docs: HashMap<String, HashMap<String, String>>,
-    pub doc_info: HashMap<String, HashMap<String, usize>>,
+    pub docs: BTreeMap<String, BTreeMap<String, String>>,
+    pub doc_info: BTreeMap<String, BTreeMap<String, usize>>,
     // Redundant with docs.len(), but needed for serialization
     pub length: usize,
 }
@@ -18,8 +18,8 @@ impl DocumentStore {
     pub fn new(save: bool) -> Self {
         DocumentStore {
             save: save,
-            docs: HashMap::new(),
-            doc_info: HashMap::new(),
+            docs: BTreeMap::new(),
+            doc_info: BTreeMap::new(),
             length: 0,
         }
     }
@@ -36,16 +36,16 @@ impl DocumentStore {
         self.docs.contains_key(doc_ref)
     }
 
-    pub fn add_doc(&mut self, doc_ref: &str, doc: HashMap<String, String>) {
+    pub fn add_doc(&mut self, doc_ref: &str, doc: BTreeMap<String, String>) {
         if !self.has_doc(doc_ref) {
             self.length += 1;
         }
 
         self.docs
-            .insert(doc_ref.into(), if self.save { doc } else { HashMap::new() });
+            .insert(doc_ref.into(), if self.save { doc } else { BTreeMap::new() });
     }
 
-    pub fn get_doc(&self, doc_ref: &str) -> Option<HashMap<String, String>> {
+    pub fn get_doc(&self, doc_ref: &str) -> Option<BTreeMap<String, String>> {
         self.docs.get(doc_ref.into()).cloned()
     }
 
@@ -60,7 +60,7 @@ impl DocumentStore {
     pub fn add_field_length(&mut self, doc_ref: &str, field: &str, length: usize) {
         self.doc_info
             .entry(doc_ref.into())
-            .or_insert(HashMap::new())
+            .or_insert(BTreeMap::new())
             .insert(field.into(), length);
     }
 
@@ -84,7 +84,7 @@ mod tests {
     #[test]
     fn add_doc_tokens() {
         let mut store = DocumentStore::new(true);
-        let doc = hashmap!{ "title".into() => "eggs bread".into() };
+        let doc = btreemap!{ "title".into() => "eggs bread".into() };
 
         store.add_doc("1", doc.clone());
         assert_eq!(store.get_doc("1").unwrap(), doc);
@@ -93,7 +93,7 @@ mod tests {
     #[test]
     fn create_doc_no_store() {
         let mut store = DocumentStore::new(false);
-        let doc = hashmap!{ "title".into() => "eggs bread".into() };
+        let doc = btreemap!{ "title".into() => "eggs bread".into() };
 
         store.add_doc("1", doc);
         assert_eq!(store.len(), 1);
@@ -104,8 +104,8 @@ mod tests {
     #[test]
     fn add_doc_no_store() {
         let mut store = DocumentStore::new(false);
-        let doc1 = hashmap!{ "title".into() => "eggs bread".into() };
-        let doc2 = hashmap!{ "title".into() => "hello world".into() };
+        let doc1 = btreemap!{ "title".into() => "eggs bread".into() };
+        let doc2 = btreemap!{ "title".into() => "hello world".into() };
 
         store.add_doc("1", doc1);
         store.add_doc("2", doc2);
@@ -130,59 +130,59 @@ mod tests {
     #[test]
     fn get_doc_no_store() {
         let mut store = DocumentStore::new(false);
-        let doc1 = hashmap!{ "title".into() => "eggs bread".into() };
-        let doc2 = hashmap!{ "title".into() => "hello world".into() };
+        let doc1 = btreemap!{ "title".into() => "eggs bread".into() };
+        let doc2 = btreemap!{ "title".into() => "hello world".into() };
 
         store.add_doc("1", doc1);
         store.add_doc("2", doc2);
         assert_eq!(store.len(), 2);
         assert_eq!(store.is_stored(), false);
-        assert_eq!(store.get_doc("1").unwrap(), HashMap::new());
-        assert_eq!(store.get_doc("2").unwrap(), HashMap::new());
+        assert_eq!(store.get_doc("1").unwrap(), BTreeMap::new());
+        assert_eq!(store.get_doc("2").unwrap(), BTreeMap::new());
     }
 
     #[test]
     fn get_nonexistant_doc_no_store() {
         let mut store = DocumentStore::new(false);
-        let doc1 = hashmap!{ "title".into() => "eggs bread".into() };
-        let doc2 = hashmap!{ "title".into() => "hello world".into() };
+        let doc1 = btreemap!{ "title".into() => "eggs bread".into() };
+        let doc2 = btreemap!{ "title".into() => "hello world".into() };
 
         store.add_doc("1", doc1);
         store.add_doc("2", doc2);
         assert_eq!(store.len(), 2);
         assert_eq!(store.is_stored(), false);
         assert_eq!(store.get_doc("6"), None);
-        assert_eq!(store.get_doc("2").unwrap(), HashMap::new());
+        assert_eq!(store.get_doc("2").unwrap(), BTreeMap::new());
     }
 
     #[test]
     fn remove_doc_no_store() {
         let mut store = DocumentStore::new(false);
-        let doc1 = hashmap!{ "title".into() => "eggs bread".into() };
-        let doc2 = hashmap!{ "title".into() => "hello world".into() };
+        let doc1 = btreemap!{ "title".into() => "eggs bread".into() };
+        let doc2 = btreemap!{ "title".into() => "hello world".into() };
 
         store.add_doc("1", doc1);
         store.add_doc("2", doc2);
         store.remove_doc("1");
         assert_eq!(store.len(), 1);
         assert_eq!(store.is_stored(), false);
-        assert_eq!(store.get_doc("2").unwrap(), HashMap::new());
+        assert_eq!(store.get_doc("2").unwrap(), BTreeMap::new());
         assert_eq!(store.get_doc("1"), None);
     }
 
     #[test]
     fn remove_nonexistant_doc() {
         let mut store = DocumentStore::new(false);
-        let doc1 = hashmap!{ "title".into() => "eggs bread".into() };
-        let doc2 = hashmap!{ "title".into() => "hello world".into() };
+        let doc1 = btreemap!{ "title".into() => "eggs bread".into() };
+        let doc2 = btreemap!{ "title".into() => "hello world".into() };
 
         store.add_doc("1", doc1);
         store.add_doc("2", doc2);
         store.remove_doc("8");
         assert_eq!(store.len(), 2);
         assert_eq!(store.is_stored(), false);
-        assert_eq!(store.get_doc("2").unwrap(), HashMap::new());
-        assert_eq!(store.get_doc("1").unwrap(), HashMap::new());
+        assert_eq!(store.get_doc("2").unwrap(), BTreeMap::new());
+        assert_eq!(store.get_doc("1").unwrap(), BTreeMap::new());
     }
 
     #[test]
@@ -190,7 +190,7 @@ mod tests {
         let mut store = DocumentStore::new(true);
 
         assert_eq!(store.len(), 0);
-        store.add_doc("1", hashmap!{ "title".into() => "eggs bread".into() });
+        store.add_doc("1", btreemap!{ "title".into() => "eggs bread".into() });
         assert_eq!(store.len(), 1);
     }
 
@@ -199,10 +199,10 @@ mod tests {
         let mut store = DocumentStore::new(true);
 
         assert_eq!(store.len(), 0);
-        store.add_doc("1", hashmap!{ "title".into() => "eggs bread".into() });
+        store.add_doc("1", btreemap!{ "title".into() => "eggs bread".into() });
         assert_eq!(
             store.get_doc("1").unwrap(),
-            hashmap!{ "title".into() => "eggs bread".into() }
+            btreemap!{ "title".into() => "eggs bread".into() }
         );
     }
 
@@ -213,26 +213,26 @@ mod tests {
         assert_eq!(store.len(), 0);
         store.add_doc(
             "1",
-            hashmap!{
+            btreemap!{
                 "title".into() => "eggs bread".into()
             },
         );
         store.add_doc(
             "2",
-            hashmap!{
+            btreemap!{
                 "title".into() => "boo bar".into()
             },
         );
         store.add_doc(
             "3",
-            hashmap!{
+            btreemap!{
                 "title".into() => "oracle".into(),
                 "body".into() => "Oracle is demonspawn".into()
             },
         );
         assert_eq!(
             store.get_doc("3").unwrap(),
-            hashmap!{
+            btreemap!{
                 "title".into() => "oracle".into(),
                 "body".into() => "Oracle is demonspawn".into()
             }
@@ -247,19 +247,19 @@ mod tests {
         assert_eq!(store.len(), 0);
         store.add_doc(
             "1",
-            hashmap!{
+            btreemap!{
                 "title".into() => "eggs bread".into()
             },
         );
         store.add_doc(
             "2",
-            hashmap!{
+            btreemap!{
                 "title".into() => "boo bar".into()
             },
         );
         store.add_doc(
             "3",
-            hashmap!{
+            btreemap!{
                 "title".into() => "oracle".into(),
                 "body".into() => "Oracle is demonspawn".into()
             },
@@ -274,7 +274,7 @@ mod tests {
         let mut store = DocumentStore::new(true);
 
         assert!(!store.has_doc("foo"));
-        store.add_doc("foo", hashmap!{ "title".into() => "eggs bread".into() });
+        store.add_doc("foo", btreemap!{ "title".into() => "eggs bread".into() });
         assert!(store.has_doc("foo"));
     }
 
@@ -282,7 +282,7 @@ mod tests {
     fn remove_doc() {
         let mut store = DocumentStore::new(true);
 
-        store.add_doc("foo", hashmap!{ "title".into() => "eggs bread".into() });
+        store.add_doc("foo", btreemap!{ "title".into() => "eggs bread".into() });
         assert!(store.has_doc("foo"));
         assert_eq!(store.len(), 1);
         store.remove_doc("foo");
@@ -294,7 +294,7 @@ mod tests {
     fn remove_nonexistant_store() {
         let mut store = DocumentStore::new(true);
 
-        store.add_doc("foo", hashmap!{ "title".into() => "eggs bread".into() });
+        store.add_doc("foo", btreemap!{ "title".into() => "eggs bread".into() });
         assert!(store.has_doc("foo"));
         assert_eq!(store.len(), 1);
         store.remove_doc("bar");
@@ -306,7 +306,7 @@ mod tests {
     fn add_field_len() {
         let mut store = DocumentStore::new(true);
 
-        store.add_doc("foo", hashmap!{ "title".into() => "eggs bread".into() });
+        store.add_doc("foo", btreemap!{ "title".into() => "eggs bread".into() });
         store.add_field_length("foo", "title", 2);
         assert_eq!(store.get_field_length("foo", "title"), 2);
     }
@@ -315,7 +315,7 @@ mod tests {
     fn add_field_length_multiple() {
         let mut store = DocumentStore::new(true);
 
-        store.add_doc("foo", hashmap!{ "title".into() => "eggs bread".into() });
+        store.add_doc("foo", btreemap!{ "title".into() => "eggs bread".into() });
         store.add_field_length("foo", "title", 2);
         store.add_field_length("foo", "body", 10);
         assert_eq!(store.get_field_length("foo", "title"), 2);

--- a/src/inverted_index.rs
+++ b/src/inverted_index.rs
@@ -1,6 +1,6 @@
 //! Implements an elasticlunr.js inverted index. Most users do not need to use this module directly.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 struct TermFrequency {
@@ -10,19 +10,19 @@ struct TermFrequency {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct IndexItem {
-    pub docs: HashMap<String, TermFrequency>,
+    pub docs: BTreeMap<String, TermFrequency>,
     #[serde(rename = "df")]
     pub doc_freq: i64,
     #[serde(flatten)]
-    pub children: HashMap<String, IndexItem>,
+    pub children: BTreeMap<String, IndexItem>,
 }
 
 impl IndexItem {
     fn new() -> Self {
         IndexItem {
-            docs: HashMap::new(),
+            docs: BTreeMap::new(),
             doc_freq: 0,
-            children: HashMap::new(),
+            children: BTreeMap::new(),
         }
     }
 
@@ -105,7 +105,7 @@ impl InvertedIndex {
         self.root.remove_token(doc_ref, token)
     }
 
-    pub fn get_docs(&self, token: &str) -> Option<HashMap<String, f64>> {
+    pub fn get_docs(&self, token: &str) -> Option<BTreeMap<String, f64>> {
         self.root.get_node(token).map(|node| {
             node.docs
                 .iter()
@@ -222,19 +222,19 @@ mod tests {
         inverted_index.add_token("123", token, 1.);
         assert_eq!(
             inverted_index.get_docs(token).unwrap(),
-            hashmap!{
+            btreemap!{
                 "123".into() => 1.
             }
         );
 
-        assert_eq!(inverted_index.get_docs(""), Some(HashMap::new()));
+        assert_eq!(inverted_index.get_docs(""), Some(BTreeMap::new()));
 
         inverted_index.add_token("234", "boo", 100.);
         inverted_index.add_token("345", "too", 101.);
 
         assert_eq!(
             inverted_index.get_docs(token).unwrap(),
-            hashmap!{
+            btreemap!{
                 "123".into() => 1.
             }
         );
@@ -244,7 +244,7 @@ mod tests {
 
         assert_eq!(
             inverted_index.get_docs(token).unwrap(),
-            hashmap!{
+            btreemap!{
                 "123".into() => 1.,
                 "234".into() => 100.,
                 "345".into() => 101.,
@@ -285,13 +285,13 @@ mod tests {
         inverted_index.add_token("123", "foo", 1.);
         assert_eq!(
             inverted_index.get_docs("foo").unwrap(),
-            hashmap!{
+            btreemap!{
                 "123".into() => 1.,
             }
         );
 
         inverted_index.remove_token("123", "foo");
-        assert_eq!(inverted_index.get_docs("foo"), Some(HashMap::new()));
+        assert_eq!(inverted_index.get_docs("foo"), Some(BTreeMap::new()));
         assert_eq!(inverted_index.get_doc_frequency("foo"), 0);
         assert_eq!(inverted_index.has_token("foo"), true);
     }
@@ -306,7 +306,7 @@ mod tests {
 
         assert_eq!(
             inverted_index.get_docs("foo").unwrap(),
-            hashmap!{
+            btreemap!{
                 "123".into() => 1.
             }
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub mod inverted_index;
 pub mod lang;
 pub mod pipeline;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use document_store::DocumentStore;
 use inverted_index::InvertedIndex;
@@ -151,7 +151,7 @@ pub struct Index {
     #[serde(rename = "ref")]
     pub ref_field: String,
     pub version: &'static str,
-    index: HashMap<String, InvertedIndex>,
+    index: BTreeMap<String, InvertedIndex>,
     pub document_store: DocumentStore,
 }
 
@@ -169,7 +169,7 @@ impl Index {
         I: IntoIterator,
         I::Item: AsRef<str>,
     {
-        let mut indices = HashMap::new();
+        let mut indices = BTreeMap::new();
         let mut field_vec = Vec::new();
         for field in fields {
             let field = field.as_ref().to_string();
@@ -201,7 +201,7 @@ impl Index {
         I: IntoIterator,
         I::Item: AsRef<str>,
     {
-        let mut indices = HashMap::new();
+        let mut indices = BTreeMap::new();
         let mut field_vec = Vec::new();
         for field in fields {
             let field = field.as_ref().to_string();
@@ -235,9 +235,9 @@ impl Index {
         I: IntoIterator,
         I::Item: AsRef<str>,
     {
-        let mut doc = HashMap::new();
+        let mut doc = BTreeMap::new();
         doc.insert(self.ref_field.clone(), doc_ref.into());
-        let mut token_freq = HashMap::new();
+        let mut token_freq = BTreeMap::new();
 
         for (field, value) in self.fields.iter().zip(data) {
             doc.insert(field.clone(), value.as_ref().to_string());
@@ -300,7 +300,7 @@ mod tests {
         assert_eq!(idx.document_store.len(), 1);
         assert_eq!(
             idx.document_store.get_doc("1").unwrap(),
-            hashmap!{
+            btreemap!{
                 "id".into() => "1".into(),
                 "body".into() => "this is a test".into(),
             }


### PR DESCRIPTION
mdBook is a downstream consumer of `elasticlunr-rs`, and I submitted a patch there to [enforce stable ordering of keys](https://github.com/rust-lang-nursery/mdBook/pull/692) when it converts the search index to JSON.

Another way to accomplish this is to force sorted maps in `elasticlunr` itself by using BTreeSet. (Either solution fixes the downstream issue.) I know that issue #3 says that a trie would be a better replacement though, so no worries if this is too excessive a change just for stable key ordering.