### PR TITLE
Allow to opt-out of Chinese/Japanese support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ serde_derive = "1.0.34" # First verstion to support #[serde(flatten)]
 serde_json = "1"
 strum = "0.16"
 strum_macros = "0.16"
-jieba-rs = "0.4.10"
-lindera = "0.3.4"
+jieba-rs = { version = "0.4.10", optional = true }
+lindera = { version = "0.3.4", optional = true }
 
 [features]
 default = ["languages"]
@@ -50,5 +50,5 @@ ro = ["rust-stemmers"]
 ru = ["rust-stemmers"]
 sv = ["rust-stemmers"]
 tr = ["rust-stemmers"]
-zh = ["rust-stemmers"]
-ja = ["rust-stemmers"]
+zh = ["jieba-rs"]
+ja = ["lindera"]

--- a/tests/test-lang.rs
+++ b/tests/test-lang.rs
@@ -9,7 +9,9 @@ use std::path::Path;
 
 use elasticlunr::pipeline::tokenize;
 #[cfg(feature = "zh")]
-use elasticlunr::pipeline::{tokenize_chinese, tokenize_japanese};
+use elasticlunr::pipeline::tokenize_chinese;
+#[cfg(feature = "ja")]
+use elasticlunr::pipeline::tokenize_japanese;
 use elasticlunr::*;
 use strum::IntoEnumIterator;
 


### PR DESCRIPTION
While it's awesome to have, the relevant support doubles the amount of dependencies from 50 to 93, pulling some data/index crates, which can blow up the compilation time considerably, even if the user doesn't require the relevant language support.

It's great to have them enabled by the default but this commit allows to opt out via `--no-default-features --features stemmer`, without forcing the user to enumerate every language already supported by the rust-stemmers crate.