### PR TITLE
Add add_doc_with_tokenizer method to Index

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -39,6 +39,9 @@ pub fn tokenize_japanese(text: &str) -> Vec<String> {
         .collect()
 }
 
+/// The function type used for the tokenizer.
+pub type TokenizerFn = fn(&str) -> Vec<String>;
+
 /// The function type used for each step in a pipeline.
 pub type PipelineFn = fn(String) -> Option<String>;
 


### PR DESCRIPTION
This makes it possible to build an index with custom tokenization of
document text. This is useful if indexing text with css attributes
for example.

This is a suggested fix for #32 