### PR TITLE
Update lindera and lindera-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ serde = "1"
 serde_derive = "1.0.34" # First verstion to support #[serde(flatten)]
 serde_json = "1"
 jieba-rs = { version = "0.6", optional = true }
-lindera = { version = "0.13", optional = true, features = ["ipadic"] }
-lindera-core = { version = "0.13", optional = true }
+lindera = { version = "0.14", optional = true, features = ["ipadic"] }
+lindera-core = { version = "0.13.5", optional = true }
 
 [features]
 languages = ["ar", "da", "de", "du", "es", "fi", "fr", "it", "ja", "no", "pt", "ro", "ru", "sv", "tr", "zh"]


### PR DESCRIPTION
Fixes https://github.com/mattico/elasticlunr-rs/issues/46

Due to the undocumented breaking change introduced in lindare-core v0.13.5[^1], lindera \<0.14 and lindera-core \>=0.13.5 are now incompatible.

[^1]: https://github.com/lindera-morphology/lindera/pull/198/files#diff-0bdaabb894480af904f30980ceeb337ffcfdf7b50d08e2877143a0ad56f5f600L18
