### PR TITLE
Faster English Porter's Stemmer

### DIFF
--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -95,14 +95,6 @@ impl Stemmer {
 ///
 /// Note that only lower case sequences are stemmed. get(...) automatically
 /// lowercases the string before processing.
-///
-///
-/// Typical usage is:
-///
-///     let b = "pencils";
-///     let res = stem::get(b);
-///     assert_eq!(res, Ok("pencil".to_string()));
-///
 struct PorterStemmer {
     b: Vec<u8>,
     k: usize,

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -57,10 +57,6 @@ fn trimmer(token: String) -> Option<String> {
     )
 }
 
-// This is a direct port of the stemmer from elasticlunr.js
-// It's not very efficient and very not-rusty, but it
-// generates identical output.
-
 #[derive(Clone)]
 struct Stemmer;
 
@@ -83,6 +79,14 @@ impl Stemmer {
         get(word).ok()
     }
 }
+
+/// This stemmer implementation is taken directly from rust-stem
+/// (https://github.com/minhnhdo/rust-stem) which is licensed under the MIT
+/// License as follows:
+/// 
+/// The MIT License (MIT)
+///
+/// Copyright (c) 2013 Do Nhat Minh
 
 /// Member b is a vector of bytes holding a word to be stemmed.
 /// The letters are in b[0], b[1] ... ending at b[z->k]. Member k is readjusted


### PR DESCRIPTION
This gets rid of the extremely slow regex based implementation & introduces an all new implementation taken from [rust-stem](https://github.com/minhnhdo/rust-stem). I had to make a few changes to make it compatible with elasticlunr.

How fast is it exactly?

Old:
```
create_index            time:   [3.4562 ms 3.4664 ms 3.4838 ms]
```
New:
```
create_index            time:   [509.29 µs 511.17 µs 513.40 µs]                         
                        change: [-85.031% -84.680% -84.282%] (p = 0.00 < 0.05)
                        Performance has improved.
```

All tests are passing without any changes to them or the outputs so this is 100% compatible. I bet this can be further improved but it's a good start.