### PR TITLE
Prevent subtract with overflow for word "ion"

### DIFF
--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -515,7 +515,7 @@ impl PorterStemmer {
                 }
             }
             b'o' => {
-                if self.ends("ion") && (self.b[self.j - 1] == b's' || self.b[self.j - 1] == b't') {
+                if self.ends("ion") && self.j > 0 && (self.b[self.j - 1] == b's' || self.b[self.j - 1] == b't') {
                 } else if self.ends("ou") {
                 } else {
                     return;
@@ -672,6 +672,7 @@ mod tests {
             ("constance", "constanc"),
             ("constancy", "constanc"),
             ("constant", "constant"),
+            ("ion", "ion"),
             ("knack", "knack"),
             ("knackeries", "knackeri"),
             ("knacks", "knack"),


### PR DESCRIPTION
I recently ran into this error through an mdbook build, also reported by someone else [here](https://github.com/rust-lang/mdBook/issues/971#issuecomment-2727816379).

Luckily it was pretty straightforward to find and fix :) Thanks for maintaining this repository!

See also:
- https://github.com/minhnhdo/rust-stem/pull/9
- Release 2 notes from the reference implementation:
```plain
   Release 2: 11 Apr 2013
       fixes a bug noted by Matt Patenaude <matt@mattpatenaude.com>,

       case 'o': if (ends("\03" "ion") && (b[j] == 's' || b[j] == 't')) break;
           ==>
       case 'o': if (ends("\03" "ion") && j >= k0 && (b[j] == 's' || b[j] == 't')) break;

       to avoid accessing b[k0-1] when the word in b is "ion".
```