### PR TITLE
CI Refresh and Clippy Fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 * text eol=lf
+
+# Take both sides when merging changelog entries instead of conflicting.
+# Union keeps every line from both sides in an arbitrary order, so re-read the
+# result after a merge to fix ordering and drop any duplicated entries.
+CHANGELOG.md merge=union

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: [ "*" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,11 @@ jobs:
       - name: rustfmt
         run: cargo fmt --all --check
 
-      # Not blocking yet: the tree still has a backlog of warnings. Reported so
-      # the backlog is visible, and made blocking once it is cleared.
       - name: clippy
-        continue-on-error: true
-        run: cargo clippy --all-features --all-targets
+        run: cargo clippy --all-features --all-targets -- -D warnings
+
+      - name: clippy (no features)
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: rustdoc
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,67 +3,146 @@ name: CI
 on:
   push:
     branches: [ master ]
-    tags: [ '*' ]
-  workflow_dispatch:
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: '1'
 
 jobs:
-  ci:
-    runs-on: ubuntu-latest
+  test:
+    name: Test ${{ matrix.rust }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    # Nightly regressions are upstream's problem, not a reason to block a PR.
+    continue-on-error: ${{ matrix.rust == 'nightly' }}
     strategy:
+      fail-fast: false
       matrix:
-        rust:
-          - stable
-          - beta
-          - nightly
+        os: [ ubuntu-latest ]
+        rust: [ stable, beta, nightly ]
+        include:
+          - { os: windows-latest, rust: stable }
+          - { os: macos-latest, rust: stable }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup ${{ matrix.rust }} toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
 
-      - name: Build (all features)
-        run: cargo build --all-features
-
-      - name: Build
-        run: cargo build
+      - name: Test (no features)
+        run: cargo test
 
       - name: Test (all features)
         run: cargo test --all-features
 
-      - name: Test
-        run: cargo test
+  features:
+    name: Feature combinations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
 
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - uses: taiki-e/install-action@cargo-hack
+
+      # Each language feature must build on its own, not just in the
+      # --all-features union.
+      - name: Check each feature
+        run: cargo hack check --each-feature --all-targets
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: rustfmt
+        run: cargo fmt --all --check
+
+      # Not blocking yet: the tree still has a backlog of warnings. Reported so
+      # the backlog is visible, and made blocking once it is cleared.
+      - name: clippy
+        continue-on-error: true
+        run: cargo clippy --all-features --all-targets
+
+      - name: rustdoc
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --all-features --no-deps
+
+      - name: Check the published package builds
+        run: cargo package --all-features
+
+  fuzz:
+    name: Fuzz target builds
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+
+      # Just a compile check; the target bit-rots against the crate API long
+      # before anyone runs an actual fuzzing session.
+      - name: Check fuzz target
+        run: cargo check --manifest-path fuzz/Cargo.toml --all-targets
 
   msrv:
+    # NB: the `env` context is not available in a job-level `name`, so the
+    # version only appears in the step names below.
+    name: MSRV and minimal versions
     runs-on: ubuntu-latest
     env:
       MSRV: '1.60.0'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Setup ${{ env.MSRV }} toolchain
+      - name: Setup ${{ env.MSRV }} and stable toolchains
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '${{ env.MSRV }}'
+          # Last entry becomes the default, so `cargo` without a `+toolchain`
+          # is stable and `override: false` keeps it that way.
+          toolchain: '${{ env.MSRV }}, stable'
           override: false
 
-      - name: Install cargo-hack
-        run: cargo +stable install --locked cargo-hack
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
 
-      - name: Install cargo-minimal-versions
-        run: cargo +stable install --locked cargo-minimal-versions
-
+      # NB: there is deliberately no plain `cargo +MSRV check` here. With no
+      # committed lockfile that resolves to the newest semver-compatible deps,
+      # several of which (e.g. thiserror >=1.0.66) now require a newer rustc
+      # than the MSRV. minimal-versions is what actually pins the floor.
       - name: Check minimal versions on stable
         run: cargo +stable minimal-versions check
 
       - name: Test minimal versions on stable
         run: cargo +stable minimal-versions test
 
+      # NB: --all-features is deliberately omitted here. Some transitive deps
+      # of the lindera/jieba trees declare unbounded lower bounds that resolve
+      # to pre-1.0-era crates which no longer compile at all.
       - name: Check minimal versions on MSRV
         run: cargo +${{ env.MSRV }} minimal-versions check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - `Default` implementations for every `Language` type, delegating to their existing `new()`.
  - `TokenizerFn` type alias for the boxed tokenizer accepted by `IndexBuilder::add_field_with_tokenizer`.
+ - A `cargo-fuzz` target for the English pipeline ([#58](https://github.com/mattico/elasticlunr-rs/pull/58))
 
 ### Changed
  - Cleaned up all Clippy warnings.
 
 ### Fixed
  - Fixed tokens from earlier fields leaking into later fields' indices, inflating term and document frequencies ([#60](https://github.com/mattico/elasticlunr-rs/pull/60))
+ - Fixed a panic (subtract with overflow) when the English stemmer was given the word "ion" ([#57](https://github.com/mattico/elasticlunr-rs/pull/57))
+ - Fixed a panic (subtract with overflow) when the English stemmer was given a word ending in "eing" ([#58](https://github.com/mattico/elasticlunr-rs/pull/58))
 
-## [3.0.3] - 2025-03-16
+## [3.0.3] - 2025-03-16 [YANKED]
+This release was yanked because the rewritten English stemmer could panic on
+certain inputs. Use 3.0.2 or a later release instead.
+
 ### Changed
  - Rewrote the English stemmer for improved performance ([#48](https://github.com/mattico/elasticlunr-rs/pull/48))
  - Changed the rust-version in Cargo.toml to match the Minimum Supported Rust Version (1.60.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - `Default` implementations for every `Language` type, delegating to their existing `new()`.
+ - `TokenizerFn` type alias for the boxed tokenizer accepted by `IndexBuilder::add_field_with_tokenizer`.
+
+### Changed
+ - Cleaned up all Clippy warnings.
+
 ### Fixed
  - Fixed tokens from earlier fields leaking into later fields' indices, inflating term and document frequencies ([#60](https://github.com/mattico/elasticlunr-rs/pull/60))
 

--- a/src/document_store.rs
+++ b/src/document_store.rs
@@ -66,7 +66,7 @@ impl DocumentStore {
     pub fn add_field_length(&mut self, doc_ref: &str, field: &str, length: usize) {
         self.doc_info
             .entry(doc_ref.into())
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .insert(field.into(), length);
     }
 
@@ -103,8 +103,8 @@ mod tests {
 
         store.add_doc("1", doc);
         assert_eq!(store.len(), 1);
-        assert_eq!(store.is_stored(), false);
-        assert_eq!(store.has_doc("1"), true);
+        assert!(!store.is_stored());
+        assert!(store.has_doc("1"));
     }
 
     #[test]
@@ -116,21 +116,21 @@ mod tests {
         store.add_doc("1", doc1);
         store.add_doc("2", doc2);
         assert_eq!(store.len(), 2);
-        assert_eq!(store.is_stored(), false);
-        assert_eq!(store.has_doc("1"), true);
-        assert_eq!(store.has_doc("2"), true);
+        assert!(!store.is_stored());
+        assert!(store.has_doc("1"));
+        assert!(store.has_doc("2"));
     }
 
     #[test]
     fn is_stored_true() {
         let store = DocumentStore::new(true);
-        assert_eq!(store.is_stored(), true);
+        assert!(store.is_stored());
     }
 
     #[test]
     fn is_stored_false() {
         let store = DocumentStore::new(false);
-        assert_eq!(store.is_stored(), false);
+        assert!(!store.is_stored());
     }
 
     #[test]
@@ -142,7 +142,7 @@ mod tests {
         store.add_doc("1", doc1);
         store.add_doc("2", doc2);
         assert_eq!(store.len(), 2);
-        assert_eq!(store.is_stored(), false);
+        assert!(!store.is_stored());
         assert_eq!(store.get_doc("1").unwrap(), BTreeMap::new());
         assert_eq!(store.get_doc("2").unwrap(), BTreeMap::new());
     }
@@ -156,7 +156,7 @@ mod tests {
         store.add_doc("1", doc1);
         store.add_doc("2", doc2);
         assert_eq!(store.len(), 2);
-        assert_eq!(store.is_stored(), false);
+        assert!(!store.is_stored());
         assert_eq!(store.get_doc("6"), None);
         assert_eq!(store.get_doc("2").unwrap(), BTreeMap::new());
     }
@@ -171,7 +171,7 @@ mod tests {
         store.add_doc("2", doc2);
         store.remove_doc("1");
         assert_eq!(store.len(), 1);
-        assert_eq!(store.is_stored(), false);
+        assert!(!store.is_stored());
         assert_eq!(store.get_doc("2").unwrap(), BTreeMap::new());
         assert_eq!(store.get_doc("1"), None);
     }
@@ -186,7 +186,7 @@ mod tests {
         store.add_doc("2", doc2);
         store.remove_doc("8");
         assert_eq!(store.len(), 2);
-        assert_eq!(store.is_stored(), false);
+        assert!(!store.is_stored());
         assert_eq!(store.get_doc("2").unwrap(), BTreeMap::new());
         assert_eq!(store.get_doc("1").unwrap(), BTreeMap::new());
     }

--- a/src/inverted_index.rs
+++ b/src/inverted_index.rs
@@ -18,10 +18,6 @@ struct IndexItem {
 }
 
 impl IndexItem {
-    fn new() -> Self {
-        Default::default()
-    }
-
     fn serialize<S>(map: &BTreeMap<char, IndexItem>, ser: S) -> Result<S::Ok, S::Error>
     where
         S: ::serde::Serializer,
@@ -40,14 +36,11 @@ impl IndexItem {
     fn add_token(&mut self, doc_ref: &str, token: &str, term_freq: f64) {
         let mut iter = token.chars();
         if let Some(character) = iter.next() {
-            let mut item = self
-                .children
-                .entry(character)
-                .or_insert_with(IndexItem::new);
+            let mut item = self.children.entry(character).or_default();
 
             for character in iter {
                 let tmp = item;
-                item = tmp.children.entry(character).or_insert_with(IndexItem::new);
+                item = tmp.children.entry(character).or_default();
             }
 
             if !item.docs.contains_key(doc_ref) {
@@ -61,11 +54,7 @@ impl IndexItem {
     fn get_node(&self, token: &str) -> Option<&IndexItem> {
         let mut root = self;
         for ch in token.chars() {
-            if let Some(item) = root.children.get(&ch) {
-                root = item;
-            } else {
-                return None;
-            }
+            root = root.children.get(&ch)?;
         }
 
         Some(root)
@@ -297,7 +286,7 @@ mod tests {
         inverted_index.remove_token("123", "foo");
         assert_eq!(inverted_index.get_docs("foo"), Some(BTreeMap::new()));
         assert_eq!(inverted_index.get_doc_frequency("foo"), 0);
-        assert_eq!(inverted_index.has_token("foo"), true);
+        assert!(inverted_index.has_token("foo"));
     }
 
     #[test]

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -7,6 +7,12 @@ use regex::Regex;
 /// Designed to be compatibile with the included Javascript implementation. See `js/lunr.ar.js`.
 pub struct Arabic {}
 
+impl Default for Arabic {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Arabic {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Danish {}
 
+impl Default for Danish {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Danish {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct German {}
 
+impl Default for German {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl German {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/du.rs
+++ b/src/lang/du.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Dutch {}
 
+impl Default for Dutch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Dutch {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -19,6 +19,12 @@ pub struct English {
     stemmer: Stemmer,
 }
 
+impl Default for English {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl English {
     pub fn new() -> Self {
         let stemmer = Stemmer::new();
@@ -80,13 +86,13 @@ impl Stemmer {
     }
 }
 
-/// This stemmer implementation is taken directly from rust-stem
-/// (https://github.com/minhnhdo/rust-stem) which is licensed under the MIT
-/// License as follows:
-/// 
-/// The MIT License (MIT)
-///
-/// Copyright (c) 2013 Do Nhat Minh
+// This stemmer implementation is taken directly from rust-stem
+// (https://github.com/minhnhdo/rust-stem) which is licensed under the MIT
+// License as follows:
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 Do Nhat Minh
 
 /// Member b is a vector of bytes holding a word to be stemmed.
 /// The letters are in b[0], b[1] ... ending at b[z->k]. Member k is readjusted
@@ -105,7 +111,7 @@ impl PorterStemmer {
     fn new(word: &str) -> Result<PorterStemmer, &'static str> {
         let b = word.to_ascii_lowercase().into_bytes();
         let k = b.len();
-        Ok(PorterStemmer { b: b, k: k, j: 0 })
+        Ok(PorterStemmer { b, k, j: 0 })
     }
 
     /// stem.is_consonant(i) is true <=> stem[i] is a consonant
@@ -187,13 +193,7 @@ impl PorterStemmer {
     /// stem.double_consonant(i) is TRUE <=> i,(i-1) contain a double consonant.
     #[inline]
     fn double_consonant(&self, i: usize) -> bool {
-        if i < 1 {
-            false
-        } else if self.b[i] != self.b[i - 1] {
-            false
-        } else {
-            self.is_consonant(i)
-        }
+        i >= 1 && self.b[i] == self.b[i - 1] && self.is_consonant(i)
     }
 
     /// cvc(z, i) is TRUE <=> i-2,i-1,i has the form consonant - vowel - consonant
@@ -208,10 +208,7 @@ impl PorterStemmer {
         if i < 2 || !self.is_consonant(i) || self.is_consonant(i - 1) || !self.is_consonant(i - 2) {
             false
         } else {
-            match self.b[i] {
-                b'w' | b'x' | b'y' => false,
-                _ => true,
-            }
+            !matches!(self.b[i], b'w' | b'x' | b'y')
         }
     }
 
@@ -236,9 +233,7 @@ impl PorterStemmer {
     fn set_to(&mut self, s: &str) {
         let s = s.as_bytes();
         let len = s.len();
-        for i in 0..(len) {
-            self.b[self.j + i] = s[i];
-        }
+        self.b[self.j..self.j + len].copy_from_slice(s);
         self.k = self.j + len;
     }
 
@@ -315,6 +310,9 @@ impl PorterStemmer {
     /// stem.step2() maps double suffices to single ones. so -ization ( = -ize
     /// plus -ation) maps to -ize etc. note that the string before the suffix
     /// must give m(z) > 0.
+    // `ends` takes `&mut self`, and a pattern guard may not borrow the scrutinee
+    // mutably (E0510), so these arms cannot be folded into `match` guards.
+    #[allow(clippy::collapsible_match)]
     fn step2(&mut self) {
         if self.k < 2 {
             return;
@@ -327,7 +325,6 @@ impl PorterStemmer {
                 }
                 if self.ends("tional") {
                     self.r("tion");
-                    return;
                 }
             }
             b'c' => {
@@ -337,13 +334,11 @@ impl PorterStemmer {
                 }
                 if self.ends("anci") {
                     self.r("ance");
-                    return;
                 }
             }
             b'e' => {
                 if self.ends("izer") {
                     self.r("ize");
-                    return;
                 }
             }
             b'l' => {
@@ -370,7 +365,6 @@ impl PorterStemmer {
                 }
                 if self.ends("ousli") {
                     self.r("ous");
-                    return;
                 }
             }
             b'o' => {
@@ -384,7 +378,6 @@ impl PorterStemmer {
                 }
                 if self.ends("ator") {
                     self.r("ate");
-                    return;
                 }
             }
             b's' => {
@@ -402,7 +395,6 @@ impl PorterStemmer {
                 }
                 if self.ends("ousness") {
                     self.r("ous");
-                    return;
                 }
             }
             b't' => {
@@ -416,13 +408,11 @@ impl PorterStemmer {
                 }
                 if self.ends("biliti") {
                     self.r("ble");
-                    return;
                 }
             }
             b'g' => {
                 if self.ends("logi") {
                     self.r("log");
-                    return;
                 }
             } /*-DEPARTURE-*/
             /* To match the published algorithm, delete this line */
@@ -431,6 +421,7 @@ impl PorterStemmer {
     }
 
     /// stem.step3() deals with -ic-, -full, -ness etc. similar strategy to step2.
+    #[allow(clippy::collapsible_match)] // see step2
     fn step3(&mut self) {
         match self.b[self.k - 1] {
             b'e' => {
@@ -444,13 +435,11 @@ impl PorterStemmer {
                 }
                 if self.ends("alize") {
                     self.r("al");
-                    return;
                 }
             }
             b'i' => {
                 if self.ends("iciti") {
                     self.r("ic");
-                    return;
                 }
             }
             b'l' => {
@@ -460,13 +449,11 @@ impl PorterStemmer {
                 }
                 if self.ends("ful") {
                     self.r("");
-                    return;
                 }
             }
             b's' => {
                 if self.ends("ness") {
                     self.r("");
-                    return;
                 }
             }
             _ => (),
@@ -478,88 +465,33 @@ impl PorterStemmer {
         if self.k < 2 {
             return;
         }
-        match self.b[self.k - 2] {
-            b'a' => {
-                if self.ends("al") {
-                } else {
-                    return;
-                }
-            }
-            b'c' => {
-                if self.ends("ance") {
-                } else if self.ends("ence") {
-                } else {
-                    return;
-                }
-            }
-            b'e' => {
-                if self.ends("er") {
-                } else {
-                    return;
-                }
-            }
-            b'i' => {
-                if self.ends("ic") {
-                } else {
-                    return;
-                }
-            }
-            b'l' => {
-                if self.ends("able") {
-                } else if self.ends("ible") {
-                } else {
-                    return;
-                }
-            }
+        // NB: `ends` records the position of the match in `self.j` as a side
+        // effect, so these chains must stay short-circuiting and in order.
+        let matched = match self.b[self.k - 2] {
+            b'a' => self.ends("al"),
+            b'c' => self.ends("ance") || self.ends("ence"),
+            b'e' => self.ends("er"),
+            b'i' => self.ends("ic"),
+            b'l' => self.ends("able") || self.ends("ible"),
             b'n' => {
-                if self.ends("ant") {
-                } else if self.ends("ement") {
-                } else if self.ends("ment") {
-                } else if self.ends("ent") {
-                } else {
-                    return;
-                }
+                self.ends("ant") || self.ends("ement") || self.ends("ment") || self.ends("ent")
             }
+            /* takes care of -ous */
             b'o' => {
-                if self.ends("ion") && self.j > 0 && (self.b[self.j - 1] == b's' || self.b[self.j - 1] == b't') {
-                } else if self.ends("ou") {
-                } else {
-                    return;
-                }
-                /* takes care of -ous */
+                (self.ends("ion")
+                    && self.j > 0
+                    && (self.b[self.j - 1] == b's' || self.b[self.j - 1] == b't'))
+                    || self.ends("ou")
             }
-            b's' => {
-                if self.ends("ism") {
-                } else {
-                    return;
-                }
-            }
-            b't' => {
-                if self.ends("ate") {
-                } else if self.ends("iti") {
-                } else {
-                    return;
-                }
-            }
-            b'u' => {
-                if self.ends("ous") {
-                } else {
-                    return;
-                }
-            }
-            b'v' => {
-                if self.ends("ive") {
-                } else {
-                    return;
-                }
-            }
-            b'z' => {
-                if self.ends("ize") {
-                } else {
-                    return;
-                }
-            }
-            _ => return,
+            b's' => self.ends("ism"),
+            b't' => self.ends("ate") || self.ends("iti"),
+            b'u' => self.ends("ous"),
+            b'v' => self.ends("ive"),
+            b'z' => self.ends("ize"),
+            _ => false,
+        };
+        if !matched {
+            return;
         }
         if self.measure() > 1 {
             self.k = self.j
@@ -778,8 +710,67 @@ mod tests {
 
         let stemmer = Stemmer::new();
         for &(input, output) in cases.iter() {
-            let result = stemmer.stem(input.into()).unwrap();
+            let result = stemmer.stem(input).unwrap();
             assert_eq!(&result, output);
+        }
+    }
+
+    /// Each case here pins a specific branch of the Porter algorithm that
+    /// `test_stemmer` above leaves unexercised. Grouped by the rule they cover,
+    /// so a failure points straight at the responsible step.
+    #[test]
+    fn test_stemmer_branch_coverage() {
+        let cases = [
+            // cvc() must not restore a trailing 'e' when the final consonant is
+            // w, x or y. Without that exclusion these gain a spurious 'e'.
+            ("saying", "say"),
+            ("playing", "play"),
+            ("praying", "pray"),
+            ("buying", "buy"),
+            ("annoying", "annoy"),
+            ("employing", "employ"),
+            ("boxing", "box"),
+            ("snowing", "snow"),
+            ("flowing", "flow"),
+            // step1ab: -at / -bl / -iz gain an 'e'.
+            ("created", "creat"),
+            ("troubling", "troubl"),
+            ("sizing", "size"),
+            ("prizing", "prize"),
+            // step1ab: a doubled final l/s/z is *not* collapsed.
+            ("falling", "fall"),
+            ("filling", "fill"),
+            ("hissing", "hiss"),
+            ("fizzing", "fizz"),
+            // step1ab: doubled consonant otherwise collapses; cvc() restores 'e'.
+            ("matting", "mat"),
+            ("mating", "mate"),
+            ("shredded", "shred"),
+            // step1ab: cvc() true -> restore a trailing 'e' (the w/x/y cases
+            // above only cover the false branch).
+            ("hoping", "hope"),
+            ("hoped", "hope"),
+            ("filing", "file"),
+            ("coding", "code"),
+            // has_vowel() false: the stem left by -ed has no vowel at all.
+            ("bled", "bled"),
+            ("sled", "sled"),
+            // is_consonant() treats a leading 'y' as a consonant.
+            ("yielding", "yield"),
+            ("yearly", "yearli"),
+            // step1ab: -eed only shortens when the stem has measure > 0.
+            ("agreed", "agre"),
+            ("feed", "feed"),
+            // step2: the -logi -> -log rule (b'g' arm).
+            ("apology", "apolog"),
+            ("apologies", "apolog"),
+            ("archaeology", "archaeolog"),
+        ];
+
+        let stemmer = Stemmer::new();
+        for &(input, output) in cases.iter() {
+            let result = stemmer.stem(input).unwrap();
+            assert_eq!(&result, output, "stemming {:?}", input);
         }
     }
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Spanish {}
 
+impl Default for Spanish {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Spanish {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Finnish {}
 
+impl Default for Finnish {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Finnish {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct French {}
 
+impl Default for French {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl French {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Hungarian {}
 
+impl Default for Hungarian {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Hungarian {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Italian {}
 
+impl Default for Italian {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Italian {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -8,6 +8,12 @@ pub struct Japanese {
     tokenizer: Tokenizer,
 }
 
+impl Default for Japanese {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Japanese {
     pub fn new() -> Self {
         let config = TokenizerConfig {
@@ -37,7 +43,7 @@ impl Language for Japanese {
             .tokenize(text)
             .unwrap()
             .into_iter()
-            .filter_map(|tok| match tok.detail.get(0).map(|d| d.as_str()) {
+            .filter_map(|tok| match tok.detail.first().map(|d| d.as_str()) {
                 Some("助詞") | Some("助動詞") | Some("記号") | Some("UNK") => None,
                 _ => Some(tok.text.to_string()),
             })
@@ -67,7 +73,7 @@ mod tests {
 
     #[test]
     fn test_trimmer() {
-        let trimmer = RegexTrimmer::new("trimmer-ja".into(), WORD_CHARS);
+        let trimmer = RegexTrimmer::new("trimmer-ja", WORD_CHARS);
         assert_eq!(
             trimmer.filter("  こんにちは、世界！".to_string()),
             Some("こんにちは、世界".to_string())

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -5,6 +5,12 @@ use crate::pipeline::{FnWrapper, Pipeline};
 pub struct Korean {
 }
 
+impl Default for Korean {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Korean {
     pub fn new() -> Self {
         Self { }

--- a/src/lang/no.rs
+++ b/src/lang/no.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Norwegian {}
 
+impl Default for Norwegian {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Norwegian {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/pt.rs
+++ b/src/lang/pt.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Portuguese {}
 
+impl Default for Portuguese {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Portuguese {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Romanian {}
 
+impl Default for Romanian {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Romanian {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Russian {}
 
+impl Default for Russian {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Russian {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Swedish {}
 
+impl Default for Swedish {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Swedish {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -8,6 +8,12 @@ use rust_stemmers::Algorithm;
 #[derive(Clone)]
 pub struct Turkish {}
 
+impl Default for Turkish {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Turkish {
     pub fn new() -> Self {
         Self {}

--- a/src/lang/zh.rs
+++ b/src/lang/zh.rs
@@ -6,6 +6,12 @@ pub struct Chinese {
     jieba: jieba_rs::Jieba,
 }
 
+impl Default for Chinese {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Chinese {
     pub fn new() -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,13 @@ use lang::English;
 pub use lang::Language;
 pub use pipeline::Pipeline;
 
-type Tokenizer = Option<Box<dyn Fn(&str) -> Vec<String>>>;
+/// A function that splits the text of a single field into tokens.
+///
+/// Used with [`IndexBuilder::add_field_with_tokenizer`] to override the
+/// [`Language`]'s default tokenizer for one field.
+pub type TokenizerFn = Box<dyn Fn(&str) -> Vec<String>>;
+
+type Tokenizer = Option<TokenizerFn>;
 
 /// A builder for an `Index` with custom parameters.
 ///
@@ -124,11 +130,7 @@ impl IndexBuilder {
     /// # Panics
     ///
     /// Panics if a field with the name already exists.
-    pub fn add_field_with_tokenizer(
-        mut self,
-        field: &str,
-        tokenizer: Box<dyn Fn(&str) -> Vec<String>>,
-    ) -> Self {
+    pub fn add_field_with_tokenizer(mut self, field: &str, tokenizer: TokenizerFn) -> Self {
         let field = field.into();
         if self.fields.contains(&field) {
             panic!("Duplicate fields in index: {}", field);
@@ -214,6 +216,9 @@ mod ser_lang {
     use serde::{Deserializer, Serializer};
     use std::fmt;
 
+    // `serde(with = ...)` hands us a reference to the field itself, which is a
+    // `Box<dyn Language>`, so the extra indirection is not ours to remove.
+    #[allow(clippy::borrowed_box)]
     pub fn serialize<S>(lang: &Box<dyn Language>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/tests/test-index.rs
+++ b/tests/test-index.rs
@@ -82,7 +82,7 @@ const DOCS_EN: &[[&str; 2]] = &[
 ];
 
 #[cfg(feature = "ja")]
-const DOCS_JA: &'static [[&'static str; 2]] = &[
+const DOCS_JA: &[[&str; 2]] = &[
     [
         "第1章",
         "吾輩は猫である。名前はまだ無い。",

--- a/tests/test-pipeline.rs
+++ b/tests/test-pipeline.rs
@@ -12,14 +12,14 @@ fn write_output(lang: &dyn Language) {
         .join("tests")
         .join("data");
 
-    let input = base.join(&format!("{}.in.txt", code));
+    let input = base.join(format!("{}.in.txt", code));
     let mut input_str = String::new();
     File::open(&input)
         .unwrap()
         .read_to_string(&mut input_str)
         .unwrap();
 
-    let output = base.join(&format!("{}.out.txt", code));
+    let output = base.join(format!("{}.out.txt", code));
     let mut output = File::create(&output).unwrap();
 
     let pipeline = lang.make_pipeline();
@@ -36,14 +36,14 @@ fn compare_to_fixture(lang: &dyn Language) {
         .join("tests")
         .join("data");
 
-    let input = base.join(&format!("{}.in.txt", code));
+    let input = base.join(format!("{}.in.txt", code));
     let mut input_str = String::new();
     File::open(&input)
         .unwrap()
         .read_to_string(&mut input_str)
         .unwrap();
 
-    let output = base.join(&format!("{}.out.txt", code));
+    let output = base.join(format!("{}.out.txt", code));
     let mut output = BufReader::new(File::open(&output).unwrap()).lines();
 
     let pipeline = lang.make_pipeline();


### PR DESCRIPTION
Modernized the CI workflow and addressed clippy warnings. Most clippy warnings were straightforward, in `en.rs` some of the unidiomatic control flow was cleaned up. To ensure that didn't break anything some tests were added to cover missing branches.